### PR TITLE
Add two missing dependencies for Centos 6

### DIFF
--- a/README
+++ b/README
@@ -57,6 +57,8 @@ dependencies.
         mingw64-gcc \
         mingw64-headers \
         libcom_err-devel \
+        libacl-devel \
+        openldap-devel \
         popt-devel \
         zlib-devel \
         zlib-static \


### PR DESCRIPTION
Without theses, the build will not succeed:
libacl-devel
openldap-devel
